### PR TITLE
feat: add GHA workflow for continuous deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .env
 node_modules/*
+.venv
+.envrc

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -13,6 +13,8 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Authenticate to Google Cloud
         id: "auth"
         uses: "google-github-actions/auth@v2"
@@ -28,13 +30,23 @@ jobs:
           registry: us-east1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
+      - name: Set up node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Build JS and CSS assets before building docker image
+        run: |
+          npm ci
+          npm run build
       - name: Build image and push to Google Artifact Registry
         id: docker-build
         uses: docker/build-push-action@v6
         with:
+          context: . # instead of using clean pull of repo, use the "dirty" i.e. "has npm build artifacts" version
           push: true
           tags: |
             "us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:latest"
+            "us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:${{ github.ref_name }}"
             "us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:${{ github.sha }}"
       - name: Redeploy Cloud Run service
         uses: google-github-actions/deploy-cloudrun@v2


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #63.

# Testing

* temporarily disabled branch protection so I could push a stub workflow to `main` so that I could trigger the workflow on this branch via the `workflow_dispatch` UI
* https://github.com/catalyst-cooperative/eel-hole/actions/runs/17653931566/job/50171688824
* saw that there's a new revision in cloud run: 
<img width="1018" height="314" alt="image" src="https://github.com/user-attachments/assets/a9fa5d43-ec03-4dbc-9467-6815e568649e" />

* verified that that revision uses the right image: it references the hash this branch had before I did another rebase onto `main`:

```
> gcloud run services describe pudl-viewer --format="value(spec.template.spec.containers[0].image)"
us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:5dd6cd435579f2a380ff9b7d4e960c5045a9ec41
```

* verified that service has new behavior: fortunately I hadn't deployed the changes from #69 yet so I could just go verify that going to https://data.catalyst.coop/asdfasdfasdfsa gave a 404
* verified that the freshly deployed service has working index.css and index.js

Separately, to test that the index.css and index.js were being included in the docker image:
* comment out the "redeploy service" chunk of the workflow
* run the workflow
* run the image locally: `> docker run -it us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:55418cd96d45aae6919405dbf72174a874d3e6de bash`
* inspect `dist` and its contents to see that `index.css` and `index.js` were there

