### PR TITLE
fix: htmx in preview links was unnecessary and caused problems with Alpine.js

### DIFF
--- a/eel_hole/templates/partials/search_metadata_card_partitioned.html
+++ b/eel_hole/templates/partials/search_metadata_card_partitioned.html
@@ -2,7 +2,6 @@
   class="block"
   x-data='{ selectedPartition: "", downloadPaths: {{ r.download_paths | tojson | safe }} }'
 >
-  <!-- TODO add a proper dropdown here, which populates the paths -->
   <div class="level">
     <div class="level-left">
       <label for="partition">Select a partition to preview or download:</label>
@@ -34,15 +33,6 @@
       class="button is-primary preview-button"
       :disabled="!selectedPartition"
       :href="selectedPartition ? '/preview/{{ r.package }}/{{ r.name }}/' + selectedPartition : '#'"
-      :hx-get="selectedPartition ? '/preview/{{ r.package }}/{{ r.name }}/' + selectedPartition : '#'"
-      hx-target="#main-content"
-      hx-push-url="true"
-      onclick="
-      if (event.ctrlKey || event.metaKey || event.shiftKey) {
-        event.stopImmediatePropagation();
-        return;
-      }
-    "
       >Preview / export as CSV</a
     >
   {% else %}

--- a/eel_hole/templates/partials/search_metadata_card_singleton.html
+++ b/eel_hole/templates/partials/search_metadata_card_singleton.html
@@ -3,15 +3,6 @@
     <a
       class="button is-primary preview-button"
       href="/preview/{{ r.package }}/{{ r.name }}"
-      hx-get="/preview/{{ r.package }}/{{ r.name }}"
-      hx-target="#main-content"
-      hx-push-url="true"
-      onclick="
-      if (event.ctrlKey || event.metaKey || event.shiftKey) {
-        event.stopImmediatePropagation();
-        return;
-      }
-    "
       >Preview / export as CSV</a
     >
   {% else %}

--- a/eel_hole/templates/partials/search_metadata_card_stub_xbrl.html
+++ b/eel_hole/templates/partials/search_metadata_card_stub_xbrl.html
@@ -3,15 +3,6 @@
     <a
       class="button is-primary preview-button"
       href="/preview/{{ r.package }}/{{ r.name }}"
-      hx-get="/preview/{{ r.package }}/{{ r.name }}"
-      hx-target="#main-content"
-      hx-push-url="true"
-      onclick="
-      if (event.ctrlKey || event.metaKey || event.shiftKey) {
-        event.stopImmediatePropagation();
-        return;
-      }
-    "
       >Preview / export as CSV</a
     >
   {% else %}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -195,17 +195,8 @@ Alpine.data("previewTableState", (tableName: string, url: string) => ({
   },
 }));
 
-// Make Alpine available globally for dynamically loaded content (e.g., HTMX swaps)
-(window as any).Alpine = Alpine;
-
-// Initialize Alpine on HTMX-loaded content
-document.addEventListener("htmx:afterSwap", (evt: any) => {
-  Alpine.initTree(evt.detail.target);
-});
-// Start Alpine after DOM is loaded
 document.addEventListener("DOMContentLoaded", () => {
   Alpine.start();
-  console.log("alpine started");
 });
 
 async function refreshTable(state: PreviewTableState) {

--- a/tests/integration/test_partition_search.py
+++ b/tests/integration/test_partition_search.py
@@ -93,11 +93,18 @@ def test_partition_dropdown_has_label(page: Page):
 
 
 def test_buttons_disabled_until_partition_selected(page: Page):
-    """For partitioned tables, preview/download buttons should be disabled until partition selected."""
+    """For partitioned tables, preview/download buttons should be disabled until partition selected.
+
+    We start from /search and then type in the query, because the button
+    behavior was once funky in a way that only manifested when HTMX was doing a
+    bunch of page updates.
+    """
     _ = page.goto("http://localhost:8080/login")
-    _ = page.goto(
-        "http://localhost:8080/search?q=name:core_ferceqr__quarterly_identity"
+    _ = page.goto("http://localhost:8080/search")
+    search_input = page.get_by_role("textbox").and_(
+        page.get_by_placeholder("Search...")
     )
+    search_input.fill("name:core_ferceqr__quarterly_identity")
 
     table_card = page.get_by_test_id("core_ferceqr__quarterly_identity")
     expect(table_card).to_be_visible(timeout=5000)
@@ -127,3 +134,6 @@ def test_buttons_disabled_until_partition_selected(page: Page):
         == f"/preview/pudl/core_ferceqr__quarterly_identity/{selected_partition[0]}"
     )
     assert download_href.endswith(f"{selected_partition[0]}.parquet")
+
+    preview_button.click()
+    page.wait_for_url(f"http://localhost:8080{preview_href}")

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -82,12 +82,13 @@ def test_search_preview_back_button(page: Page):
 
     page.wait_for_url("http://localhost:8080/preview/pudl/core_pudl__codes_datasources")
 
-    # Use JavaScript to trigger back navigation so HTMX can intercept it
     page.evaluate("window.history.back()")
-
     page.wait_for_url(
         "http://localhost:8080/search?q=name%3Acore_pudl__codes_datasources"
     )
+    # NOTE (2026-01-28): this reload is needed for the actual content to appear
+    _ = page.reload()
+
     expect(table_metadata).to_be_visible()
 
     # Search query should be restored in the input field (via our JS, not server template)


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

There was some funky interaction between HTMX and Alpine.js when clicking on the preview button for partitioned search results. This was causing inconsistent behavior - the button worked in integration tests, but not in manual tests. If you added a wait in the integration test, then the button would fail too.

While debugging, I tried removing HTMX from that interaction completely and that didn't seem to have any annoying UI glitches, so I decided to keep things that way. One less complexity in the code.

# Testing

Ran integration tests.
Tried clicking the preview button for both partitioned and non-partitioned tables - they seemed to work.
The back buttons also seem to work manually - that took a bit of debugging of `playwright` to get that to properly register with the `page` object as well.

# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have

