### PR TITLE
Add banner for ecosystem survey

### DIFF
--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -514,10 +514,10 @@ def create_app():
             partition=partition,
         )
 
-    @app.post("/dismiss-notification")
-    def dismiss_notification():
-        """Mark the beta notification as dismissed in the session."""
-        session["beta_notification_dismissed"] = True
+    @app.post("/dismiss-notification/<name>")
+    def dismiss_notification(name: str):
+        """Mark a notification as dismissed in the session."""
+        session[f"{name}_notification_dismissed"] = True
         return ""
 
     return app

--- a/eel_hole/templates/base.html
+++ b/eel_hole/templates/base.html
@@ -27,9 +27,10 @@
       {% if not session.get('beta_notification_dismissed') %}
         <div
           class="container is-fluid"
-          hx-post="/dismiss-notification"
+          hx-post="/dismiss-notification/beta"
           hx-swap="outerHTML"
-          hx-trigger="click from:.delete"
+          hx-trigger="click from:#beta-dismiss"
+          id="beta-notification"
         >
           <div class="notification has-background-info has-text-dark my-3">
             Welcome! The PUDL data viewer is in beta right now. We filmed a
@@ -41,7 +42,7 @@
               >feedback</a
             >
             you have for the site!
-            <button class="delete"></button>
+            <button class="delete" id="beta-dismiss"></button>
           </div>
         </div>
       {% endif %}

--- a/eel_hole/templates/partials/campaign.html
+++ b/eel_hole/templates/partials/campaign.html
@@ -1,6 +1,17 @@
-        <div class="container is-fluid">
+
+      {% if not session.get('campaign_notification_dismissed') %}
+        <div
+          class="container is-fluid"
+          hx-post="/dismiss-notification/campaign"
+          hx-swap="outerHTML"
+          hx-trigger="click from:#campaign-dismiss"
+          id="campaign-notification"
+        >
           <div class="message is-link my-3">
-            <div class="message-header">The 2026 Energy Data Ecosystem Survey is now online!</div>
+            <div class="message-header">
+                <p>The 2026 Energy Data Ecosystem Survey is now online!</p>
+                <button class="delete" aria-label="delete" id="campaign-dismiss"></button>
+            </div>
             <div class="message-body">
                 <p>We know working with energy data often requires fussing with
                 formats, typos, and edge cases, and we want to help you spend less
@@ -14,3 +25,4 @@
             </div>
           </div>
         </div>
+      {% endif %}

--- a/tests/integration/test_beta_notification.py
+++ b/tests/integration/test_beta_notification.py
@@ -5,10 +5,10 @@ def test_notification_banner_dismiss(page: Page):
     """Notification banner is visible and can be dismissed by clicking delete button."""
     page.goto("http://localhost:8080/search")
 
-    notification = page.locator(".notification")
+    notification = page.locator("#beta-notification")
     expect(notification).to_be_visible()
 
-    delete_button = notification.locator(".delete")
+    delete_button = notification.locator("#beta-dismiss")
     delete_button.click()
 
     expect(notification).not_to_be_visible()
@@ -18,11 +18,11 @@ def test_notification_banner_persistence(page: Page):
     """Notification banner dismiss state persists across page loads."""
     page.goto("http://localhost:8080/search")
 
-    notification = page.locator(".notification")
+    notification = page.locator("#beta-notification")
     expect(notification).to_be_visible()
 
     # Dismiss the notification
-    delete_button = notification.locator(".delete")
+    delete_button = notification.locator("#beta-dismiss")
     delete_button.click()
     expect(notification).not_to_be_visible()
 


### PR DESCRIPTION
# Overview

What problem does this address?

The ecosystem survey is up and we want data viewer users to fill it out!

What did you change in this PR?

* Added a partial for short-term campaigns
* Filled it with an ad for the ecosystem survey
* Adjusted beta and campaign notifications to work based on IDs instead of classes, so the tests don't get confused

a la:
<img width="1192" height="551" alt="image" src="https://github.com/user-attachments/assets/51a7d6ed-b6aa-4d0f-8777-9925bdbcf594" />


## potentially debatable choices

* The banner displays below the beta notif if the beta notif is present
* ~The banner is not dismissable~
* The blue is super intense, but was the least bad of things I tried, including
  * default/grey box, blue button
  * link/blue box, default/black button
  * various outline button settings
  * full-width button
  * left-aligned button
  * right-aligned button

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Ran locally

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

