### PR TITLE
Add search bar on landing page

### DIFF
--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -247,7 +247,13 @@ def create_app():
             topics = yaml.safe_load(f)
         for topic in topics:
             topic["tables"] = [quick_pudl_resources[t] for t in topic["tables"]]
-        return render_template("welcome.html", topics=topics)
+        return render_template(
+            "welcome.html",
+            topics=topics,
+            available_packages=SEARCH_PACKAGES,
+            package="pudl",
+            query=request.args.get("q"),
+        )
 
     @login_manager.user_loader
     def __load_user(user_id):

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -252,7 +252,6 @@ def create_app():
             topics=topics,
             available_packages=SEARCH_PACKAGES,
             package="pudl",
-            query=request.args.get("q"),
         )
 
     @login_manager.user_loader

--- a/eel_hole/templates/partials/search_bar.html
+++ b/eel_hole/templates/partials/search_bar.html
@@ -1,0 +1,70 @@
+<div
+  class="block"
+  id="search-autocomplete-container"
+  x-data="searchAutocompleteState"
+  :class="{ 'is-autocomplete-open': menuVisible() }"
+  @click.outside="closeMenu()"
+  @keydown.escape.window.prevent.stop="closeMenu()"
+  @htmx:after-swap.window.camel="onAfterSwap($event)"
+>
+  <form
+    action="/search"
+    method="get"
+    hx-get="/search"
+    hx-target="#search-content"
+    hx-swap="outerHTML"
+    hx-replace-url="true"
+    x-ref="form"
+  >
+    {% if request.args.get('variants') %}
+      <input
+        type="hidden"
+        name="variants"
+        value="{{ request.args.get('variants') }}"
+      />
+    {% endif %}
+    <div class="field has-addons">
+      <p class="control">
+        <span class="select is-medium">
+          <select id="search-package-select" name="package">
+            {% for package_option in available_packages %}
+              <option {% if package == package_option %}selected{% endif %}>
+                {{ package_option }}
+              </option>
+            {% endfor %}
+          </select>
+        </span>
+      </p>
+      <p class="control is-expanded">
+        <input
+          class="input is-medium"
+          id="search-query-input"
+          type="text"
+          name="q"
+          hx-get="/search/autocomplete"
+          hx-trigger="input changed delay:120ms"
+          hx-target="#search-autocomplete"
+          hx-swap="innerHTML"
+          hx-vals='js:{"package":document.getElementById("search-package-select").value}'
+          autocomplete="off"
+          placeholder="Search..."
+          hx-replace-url="false"
+          x-ref="input"
+          @input="isExpanded = true"
+          @focus="isExpanded = true"
+          @keyup.down.prevent="moveSelection(1)"
+          @keyup.up.prevent="moveSelection(-1)"
+          @keydown.enter.prevent="submit(selectedIndex)"
+          {% if query %}value="{{ query }}"{% endif %}
+        />
+      </p>
+      <div
+        class="search-autocomplete-menu"
+        id="search-autocomplete"
+        x-ref="menu"
+        x-show="menuVisible()"
+        x-cloak
+      ></div>
+    </div>
+  </form>
+</div>

--- a/eel_hole/templates/partials/search_bar.html
+++ b/eel_hole/templates/partials/search_bar.html
@@ -10,10 +10,10 @@
   <form
     action="/search"
     method="get"
-    hx-get="/search"
-    hx-target="#search-content"
-    hx-swap="outerHTML"
-    hx-replace-url="true"
+    {% if search_bar_uses_htmx | default(true) %}
+      hx-get="/search" hx-target="#search-content" hx-swap="outerHTML"
+      hx-replace-url="true"
+    {% endif %}
     x-ref="form"
   >
     {% if request.args.get('variants') %}

--- a/eel_hole/templates/partials/search_content.html
+++ b/eel_hole/templates/partials/search_content.html
@@ -2,76 +2,7 @@
   class="data-dictionary column my-3 is-flex is-flex-direction-column"
   id="search-content"
 >
-  <div
-    class="block"
-    id="search-autocomplete-container"
-    x-data="searchAutocompleteState"
-    :class="{ 'is-autocomplete-open': menuVisible() }"
-    @click.outside="closeMenu()"
-    @keydown.escape.window.prevent.stop="closeMenu()"
-    @htmx:after-swap.window.camel="onAfterSwap($event)"
-  >
-    <form
-      action="/search"
-      method="get"
-      hx-get="/search"
-      hx-target="#search-content"
-      hx-swap="outerHTML"
-      hx-replace-url="true"
-      x-ref="form"
-    >
-      {% if request.args.get('variants') %}
-        <input
-          type="hidden"
-          name="variants"
-          value="{{ request.args.get('variants') }}"
-        />
-      {% endif %}
-      <div class="field has-addons">
-        <p class="control">
-          <span class="select is-medium">
-            <select id="search-package-select" name="package">
-              {% for package_option in available_packages %}
-                <option {% if package == package_option %}selected{% endif %}>
-                  {{ package_option }}
-                </option>
-              {% endfor %}
-            </select>
-          </span>
-        </p>
-        <p class="control is-expanded">
-          <input
-            class="input is-medium"
-            id="search-query-input"
-            type="text"
-            name="q"
-            hx-get="/search/autocomplete"
-            hx-trigger="input changed delay:120ms"
-            hx-target="#search-autocomplete"
-            hx-swap="innerHTML"
-            hx-vals='js:{"package":document.getElementById("search-package-select").value}'
-            autocomplete="off"
-            placeholder="Search..."
-            hx-replace-url="false"
-            x-ref="input"
-            @input="isExpanded = true"
-            @focus="isExpanded = true"
-            @keyup.down.prevent="moveSelection(1)"
-            @keyup.up.prevent="moveSelection(-1)"
-            @keydown.enter.prevent="submit(selectedIndex)"
-            {% if query %}value="{{ query }}"{% endif %}
-          />
-        </p>
-        <div
-          class="search-autocomplete-menu"
-          id="search-autocomplete"
-          x-ref="menu"
-          x-show="menuVisible()"
-          x-cloak
-        ></div>
-      </div>
-    </form>
-  </div>
+  {% include 'partials/search_bar.html' %}
   <div class="data-dictionary is-flex-grow-1" id="search-results">
     {% include 'partials/search_results.html' %}
   </div>

--- a/eel_hole/templates/partials/welcome_browseby.html
+++ b/eel_hole/templates/partials/welcome_browseby.html
@@ -12,8 +12,8 @@
     {% endwith %}
   </div>
   <p>
-    We recommend working with tables with the
-    <span class="is-family-code">out</span> prefix, as these tables contain the
+    We recommend starting with tables that have the
+    <span class="is-family-code">out</span> prefix, as they contain the
     most-complete data that is the easiest to work with.
   </p>
 

--- a/eel_hole/templates/partials/welcome_browseby.html
+++ b/eel_hole/templates/partials/welcome_browseby.html
@@ -2,13 +2,19 @@
   <h3 class="block title">Find the energy data you need:</h3>
   <p>
     PUDL has over 300 tables from over a dozen different datasets. You can start
-    by
-    <a href="https://data.catalyst.coop/search"
-      >searching the PUDL Data Viewer</a
-    >
-    for terms or data points you care about directly. We recommend working with
-    tables with the <span class="is-family-code">out</span> prefix, as these
-    tables contain the most-complete data that is the easiest to work with.
+    by searching the PUDL Data Viewer for terms or data points you care about
+    directly:
+  </p>
+  <div class="block">
+    <!-- NOTE 2026-06-23: in normal search, we show results in the same page via HTMX - here we navigate directly, so we pass this flag -->
+    {% with search_bar_uses_htmx=false %}
+      {% include 'partials/search_bar.html' %}
+    {% endwith %}
+  </div>
+  <p>
+    We recommend working with tables with the
+    <span class="is-family-code">out</span> prefix, as these tables contain the
+    most-complete data that is the easiest to work with.
   </p>
 
   <p>

--- a/eel_hole/templates/welcome.html
+++ b/eel_hole/templates/welcome.html
@@ -1,8 +1,13 @@
 {% extends "base.html" %}
 {% block extra_head %}
+  <!-- NOTE 2026-06-23: we need to include the search assets so the search bar and autocomplete work -->
+  <link
+    rel="stylesheet"
+    href="{{ url_for('static', filename='search.css') }}"
+  />
   <script
     type="module"
-    src="{{ url_for('static', filename='preview.js') }}"
+    src="{{ url_for('static', filename='search.js') }}"
   ></script>
 {% endblock %}
 
@@ -28,6 +33,12 @@
           <em>accessible</em>. PUDL is a free and open source project managed
           and maintained by
           <a href="https://catalyst.coop/">Catalyst Cooperative</a>.
+        </div>
+        <div class="block">
+          <!-- NOTE 2026-06-23: in normal search, we show results in the same page via HTMX - here we navigate directly, so we pass this flag -->
+          {% with search_bar_uses_htmx=false %}
+            {% include 'partials/search_bar.html' %}
+          {% endwith %}
         </div>
         <section class="block" id="find-data">
           {% include 'partials/welcome_browseby.html' %}

--- a/eel_hole/templates/welcome.html
+++ b/eel_hole/templates/welcome.html
@@ -34,12 +34,6 @@
           and maintained by
           <a href="https://catalyst.coop/">Catalyst Cooperative</a>.
         </div>
-        <div class="block">
-          <!-- NOTE 2026-06-23: in normal search, we show results in the same page via HTMX - here we navigate directly, so we pass this flag -->
-          {% with search_bar_uses_htmx=false %}
-            {% include 'partials/search_bar.html' %}
-          {% endwith %}
-        </div>
         <section class="block" id="find-data">
           {% include 'partials/welcome_browseby.html' %}
         </section>

--- a/tests/integration/test_welcome.py
+++ b/tests/integration/test_welcome.py
@@ -2,6 +2,63 @@ import re
 
 from playwright.sync_api import Page, expect
 
+from eel_hole.search import SEARCH_PACKAGES
+
+
+def test_landing_page_shows_search_controls(page: Page):
+    page.goto("http://localhost:8080/")
+
+    expect(page.locator("#search-query-input")).to_be_visible()
+    package_select = page.locator("#search-package-select")
+    expect(package_select).to_be_visible()
+    expect(package_select.locator("option")).to_have_text(SEARCH_PACKAGES)
+
+
+def test_landing_page_search_autocomplete_suggestions(page: Page):
+    page.goto("http://localhost:8080/")
+    search_input = page.get_by_role("textbox").and_(
+        page.get_by_placeholder("Search...")
+    )
+    search_input.fill("codes_datasource")
+
+    autocomplete_menu = page.locator("#search-autocomplete")
+    expect(autocomplete_menu).to_be_visible()
+    expect(autocomplete_menu.locator("a").first).to_have_text(
+        'Search for "codes_datasource"',
+    )
+    second_option = autocomplete_menu.locator("a").nth(1)
+    expect(second_option).to_contain_text("name: core_pudl__codes_datasources")
+    expect(second_option.locator("strong")).to_have_text("codes_datasource")
+
+
+def test_landing_page_search_navigates_to_search(page: Page):
+    page.goto("http://localhost:8080/")
+    search_input = page.get_by_role("textbox").and_(
+        page.get_by_placeholder("Search...")
+    )
+    search_input.fill("codes_datasource")
+    search_input.press("Enter")
+
+    expect(page).to_have_url(
+        "http://localhost:8080/search?package=pudl&q=codes_datasource"
+    )
+
+
+def test_landing_page_search_autocomplete_selection_navigates_to_search(page: Page):
+    page.goto("http://localhost:8080/")
+    search_input = page.get_by_role("textbox").and_(
+        page.get_by_placeholder("Search...")
+    )
+    search_input.fill("codes_datasource")
+
+    autocomplete_menu = page.locator("#search-autocomplete")
+    expect(autocomplete_menu).to_be_visible()
+    autocomplete_menu.locator("a").nth(1).click()
+
+    expect(page).to_have_url(
+        "http://localhost:8080/search?package=pudl&q=name%3Acore_pudl__codes_datasources"
+    )
+
 
 def test_finding_data_tabs_switch_content(page: Page):
     page.goto("http://localhost:8080/")


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

It would be nice if people could search directly from `/` instead of hiding our core functionality behind a tiny link in body text.


What did you change in this PR?

* extract search bar into reusable component
* add that component to landing page

[**AI level**: 5 - bots coded, human understands completely
](https://www.visidata.org/blog/2026/ai/#level-5%3A-bots-coded%2C-human-understands-completely)

# Testing

* integration tests
* manual clicking: verify that searching from landing page navigates to search page

# Out of scope
When clicking around, I noticed some styling issues with autocomplete, also present on the main branch, which I did not fix:

* gap between autocomplete menu and search bar
* no bottom border in autocomplete menu
* zero-height autocomplete menu sticks around after search - causing some spacing & border issues

# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have

