### PR TITLE
stub: add stub live preview workflow for dev

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,27 @@
+---
+name: pr-preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - closed
+
+jobs:
+  preview:
+    name: Print PR preview metadata
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      SERVICE_NAME: pudl-viewer-pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Print preview metadata
+        run: |
+          echo "PR number: ${PR_NUMBER}"
+          echo "Target service name: ${SERVICE_NAME}"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Step 1 of #89

What problem does this address?

We'll need a workflow to do all the deployment stuff, and we want to be able to test it on real PRs etc, so we need a stub workflow in main.

What did you change in this PR?

Add stub workflow that spits out what the service name might look like, and doesn't trigger for fork PRs.

[**AI level**: 5 - bots coded, human understands completely
](https://www.visidata.org/blog/2026/ai/#level-5%3A-bots-coded%2C-human-understands-completely) - though mostly it was "bots convinced me that I should probably just use Cloud Run for the ephemeral PR service" which doesn't really show up in this stub PR yet.

# Testing

How did you make sure this worked? 

* actionlint passed
* we'll see if a PR triggers the run properly, post-merge
* we'll also see if a fork PR triggers the action or not (hopefully not!)

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

