### PR TITLE
Add support for DBF search, download, and previews

### DIFF
--- a/eel_hole/search.py
+++ b/eel_hole/search.py
@@ -29,6 +29,7 @@ from whoosh.searching import Results, Searcher
 from eel_hole.logs import log
 from eel_hole.utils import (
     ResourceDisplay,
+    clean_ferc_dbf_resource,
     clean_ferc_xbrl_resource,
     clean_ferceqr_resource,
     clean_pudl_resource,
@@ -44,7 +45,15 @@ FERC_XBRLS = [
     "ferc714_xbrl",
 ]
 
-SEARCH_PACKAGES = ["pudl"] + FERC_XBRLS
+FERC_DBFS = [
+    "ferc1_dbf",
+    "ferc2_dbf",
+    "ferc6_dbf",
+    "ferc60_dbf",
+    # ferc714 doesn't have DBF
+]
+
+SEARCH_PACKAGES = ["pudl"] + FERC_XBRLS + FERC_DBFS
 
 SearchExecutor = Callable[[Query], Results]
 SearchVariant = Callable[[Schema, str, SearchExecutor, dict], Results]
@@ -195,7 +204,21 @@ def build_search_index(
         )
         log.info(f"Cleaned up descriptors for {ferc_xbrl}")
 
-    all_resources = pudl_resources + ferceqr_resources + ferc_xbrl_resources
+    ferc_dbf_resources = []
+    for ferc_dbf in FERC_DBFS:
+        # jun 2026 kmm - we don't have dbf directories yet to be able to use the vanilla datapackage filename
+        datapackage_uri = f"{s3_base_url}/eel-hole/{ferc_dbf}_datapackage.json"
+        ferc_dbf_package = get_datapackage(datapackage_uri)
+        log.info(f"Cleaning up descriptors for {ferc_dbf}")
+        ferc_dbf_resources.extend(
+            clean_ferc_dbf_resource(resource, ferc_dbf, datapackage_uri)
+            for resource in ferc_dbf_package.resources
+        )
+        log.info(f"Cleaned up descriptors for {ferc_dbf}")
+
+    all_resources = (
+        pudl_resources + ferceqr_resources + ferc_xbrl_resources + ferc_dbf_resources
+    )
     target_dir = Path(index_dir)
     if target_dir.exists():
         shutil.rmtree(target_dir)

--- a/eel_hole/search.py
+++ b/eel_hole/search.py
@@ -206,8 +206,7 @@ def build_search_index(
 
     ferc_dbf_resources = []
     for ferc_dbf in FERC_DBFS:
-        # jun 2026 kmm - we don't have dbf directories yet to be able to use the vanilla datapackage filename
-        datapackage_uri = f"{s3_base_url}/eel-hole/{ferc_dbf}_datapackage.json"
+        datapackage_uri = f"{s3_base_url}/eel-hole/{ferc_dbf}/datapackage.json"
         ferc_dbf_package = get_datapackage(datapackage_uri)
         log.info(f"Cleaning up descriptors for {ferc_dbf}")
         ferc_dbf_resources.extend(

--- a/eel_hole/utils.py
+++ b/eel_hole/utils.py
@@ -287,12 +287,6 @@ def clean_ferc_xbrl_resource(
     generation. Also, the table *descriptions* are useless but the table
     *titles* (not *name* which is the canonical name of the table) are merely
     nearly useless. So we replace the descriptions with the titles.
-
-    NOTE (2026-01-23): the preview_path and the download_path are currently
-    invalid links to local SQLite files on the extractor VMs. We'll need to
-    update how the datapackage is produced, potentially bringing it in line with
-    frictionless datapackage validation, as well as think about pulling out the
-    table name from the datapackage.
     """
     return SingletonResourceDisplay(
         name=resource.name,
@@ -310,6 +304,44 @@ def clean_ferc_xbrl_resource(
         # Point download path at nightly instead of eel-hole. eel-hole is for preview
         # because preview is duckdb noisy in ways we want to keep siloed for user metrics
         download_path=urljoin(datapackage_uri, resource.path).replace(
+            "eel-hole", "nightly"
+        ),
+    )
+
+
+def clean_ferc_dbf_resource(
+    resource: Resource,
+    package_name: str,
+    datapackage_uri: str,
+) -> SingletonResourceDisplay:
+    """Clean up the FERC DBF datapackage descriptions for display.
+
+    These are universally useless for now.
+
+    Note [2026-06-16] the resource path in the datapackage is currently
+    an invalid link to the local SQLite file on the extractor VM. We'll need to
+    update how the datapackage is produced, potentially bringing it in line with
+    frictionless datapackage validation, as well as think about pulling out the
+    table name from the datapackage.
+    """
+    rest, _, corrected_path = resource.path.rpartition("/")
+    return SingletonResourceDisplay(
+        name=resource.name,
+        # begin as we mean to go on
+        description=plaintext_to_html(getattr(resource, "description", "")),
+        summary=getattr(resource, "description", ""),
+        package=package_name,
+        columns=[
+            ColumnDisplay(
+                name=field.name,
+                description=plaintext_to_html(getattr(field, "type", "")),
+            )
+            for field in resource.schema.fields
+        ],
+        preview_path=urljoin(datapackage_uri, corrected_path),
+        # Point download path at nightly instead of eel-hole. eel-hole is for preview
+        # because preview is duckdb noisy in ways we want to keep siloed for user metrics
+        download_path=urljoin(datapackage_uri, corrected_path).replace(
             "eel-hole", "nightly"
         ),
     )

--- a/eel_hole/utils.py
+++ b/eel_hole/utils.py
@@ -316,7 +316,7 @@ def clean_ferc_dbf_resource(
 ) -> SingletonResourceDisplay:
     """Clean up the FERC DBF datapackage descriptions for display.
 
-    These are universally useless for now.
+    These are universally useless for now - there is no info in them other than the table and column names and types.
     """
     return SingletonResourceDisplay(
         name=resource.name,

--- a/eel_hole/utils.py
+++ b/eel_hole/utils.py
@@ -317,19 +317,12 @@ def clean_ferc_dbf_resource(
     """Clean up the FERC DBF datapackage descriptions for display.
 
     These are universally useless for now.
-
-    Note [2026-06-16] the resource path in the datapackage is currently
-    an invalid link to the local SQLite file on the extractor VM. We'll need to
-    update how the datapackage is produced, potentially bringing it in line with
-    frictionless datapackage validation, as well as think about pulling out the
-    table name from the datapackage.
     """
-    rest, _, corrected_path = resource.path.rpartition("/")
     return SingletonResourceDisplay(
         name=resource.name,
         # begin as we mean to go on
         description=plaintext_to_html(getattr(resource, "description", "")),
-        summary=getattr(resource, "description", ""),
+        summary=getattr(resource, "description", "").split("\n", 1)[0],
         package=package_name,
         columns=[
             ColumnDisplay(
@@ -338,10 +331,10 @@ def clean_ferc_dbf_resource(
             )
             for field in resource.schema.fields
         ],
-        preview_path=urljoin(datapackage_uri, corrected_path),
+        preview_path=urljoin(datapackage_uri, resource.path),
         # Point download path at nightly instead of eel-hole. eel-hole is for preview
         # because preview is duckdb noisy in ways we want to keep siloed for user metrics
-        download_path=urljoin(datapackage_uri, corrected_path).replace(
+        download_path=urljoin(datapackage_uri, resource.path).replace(
             "eel-hole", "nightly"
         ),
     )

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -31,17 +31,36 @@ def test_search_metadata(page: Page):
     )
 
 
-def test_search_for_ferc_table(page: Page):
+def test_search_for_xbrl_table(page: Page):
     _ = page.goto("http://localhost:8080/search?package=ferc6_xbrl")
     num_results = page.locator("#search-results > *").count()
     # empty query means we get a complete table listing
     assert num_results > 100
-    expect(page.get_by_test_id("identification_001_duration")).to_contain_text(
+    identification_001_duration = page.get_by_test_id("identification_001_duration")
+    expect(identification_001_duration).to_contain_text(
         "001 - Schedule - Identification - duration"
     )
-    expect(page.get_by_test_id("identification_001_duration")).to_contain_text(
-        "ferc6_xbrl"
-    )
+    expect(identification_001_duration).to_contain_text("ferc6_xbrl")
+    expect(
+        identification_001_duration.locator(
+            page.get_by_role("link", name="Download full table as Parquet")
+        )
+    ).to_have_attribute("href", re.compile(r".*\.parquet"))
+
+
+def test_search_for_dbf_table(page: Page):
+    _ = page.goto("http://localhost:8080/search?package=ferc60_dbf")
+    num_results = page.locator("#search-results > *").count()
+    # empty query means we get a complete table listing
+    assert num_results > 40
+    ident_attsttn = page.get_by_test_id("f60_001_ident_attsttn")
+    expect(ident_attsttn).to_contain_text("f60_001_ident_attsttn")
+    expect(ident_attsttn).to_contain_text("ferc60_dbf")
+    expect(
+        ident_attsttn.locator(
+            page.get_by_role("link", name="Download full table as Parquet")
+        )
+    ).to_have_attribute("href", re.compile(r".*\.parquet"))
 
 
 def test_search_preserves_variants_in_url(page: Page):


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #158.

What problem does this address?

No DBF access!

What did you change in this PR?

* Pattern DBF indexing and resource cleaning after XBRL
* Add integration test to verify we're getting the right resource paths out of the datapackage
* Clean up outdated comments

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Run integration tests
* Deploy locally and
  * select ferc1_dbf and submit a blank search
  * preview a table and check column descriptions (should be data types) and data preview (should load without console errors)

# To-do list

- [ ] decide whether treating all columns like string columns is Fine for now
- [ ] decide what to do about footnote columns
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

