### PR TITLE
chore: remove naming conventions navbar link now that we have them on landing page

### DIFF
--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -18,11 +18,6 @@
       >
         Data source documentation
       </a>
-      <a
-        class="navbar-item"
-        href="https://docs.catalyst.coop/pudl/en/latest/dev/naming_conventions.html"
-        >Table naming conventions</a
-      >
       <a class="navbar-item" href="https://youtu.be/-mU7QwAZY8c"
         >Tutorial video</a
       >


### PR DESCRIPTION
Tiny tiny cleanup that it seemed easier to open a PR for than to talk about beforehand.

If we want to keep the button we can just close this PR. Somehow I won't be too bummed about the lost work.

AI level 0 (I have never heard of an LLM)